### PR TITLE
ci: reduce R2 upload count

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_type: [release, debug]
         platform:
           - build_for: linux-x86_64
             os: ubuntu-22.04
@@ -84,7 +85,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           command: build
-          args: "--locked --release ${{ contains(matrix.platform.target, 'wasm') && '-Zbuild-std' || ' '}}"
+          args: "--locked ${{ matrix.build_type == 'release' && '--release' || ' '}} ${{ contains(matrix.platform.target, 'wasm') && '-Zbuild-std' || ' '}}"
           strip: true
           working-directory: rust
           toolchain: ${{ contains(matrix.platform.target, 'wasm') && 'nightly' || 'stable' }}
@@ -92,7 +93,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform.build_for }}_${{ matrix.platform.bin }}
-          path: rust/target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}
+          path: rust/target/${{ matrix.platform.target }}/${{ matrix.build_type }}/${{ matrix.platform.bin }}
   
   build-godot:
     # Inspired by https://github.com/abarichello/godot-ci
@@ -195,7 +196,7 @@ jobs:
         run: |
           cp deploy/cloudflare-pages/* wasm32/
           # exclude the engine file from cloudflare pages because it's too big
-          engine_hash=($(sha256sum index.side.wasm))
+          engine_hash=($(sha256sum wasm32/index.side.wasm))
           rm wasm32/index.side.wasm
           # ugly hack to force godot to pull the engine from another domain
           sed -i "s/{{{DIR}}}/release_${GODOT_VERSION}_${engine_hash[1]}/" deploy/templates/readAsyncNew

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -195,10 +195,11 @@ jobs:
         run: |
           cp deploy/cloudflare-pages/* wasm32/
           # exclude the engine file from cloudflare pages because it's too big
-          mkdir wasm32engine
-          mv wasm32/index.side.wasm ./wasm32engine
+          engine_hash=($(sha256sum index.side.wasm))
+          rm wasm32/index.side.wasm
           # ugly hack to force godot to pull the engine from another domain
-          sed -e '/readAsync = (url, onload, onerror) => {/{r deploy/templates/readAsyncNew' -e 'd;}' wasm32/index.js > _index.js
+          sed -i "s/{{{DIR}}}/release_${GODOT_VERSION}_${engine_hash[1]}/" deploy/templates/readAsyncNew
+          sed -e '/readAsync = (url, onload, onerror) => {/{r readAsyncNew' -e 'd;}' wasm32/index.js > _index.js
           mv _index.js wasm32/index.js
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
@@ -209,14 +210,3 @@ jobs:
           directory: wasm32
           wranglerVersion: '3'
           branch: ${{ github.head_ref || github.ref_name }}
-      - name: Upload engine to cloudflare R2
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --delete
-        env:
-          AWS_S3_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          AWS_S3_BUCKET: ${{ secrets.R2_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_REGION: auto
-          SOURCE_DIR: wasm32engine

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
             target: aarch64-apple-darwin
             bin: libblocks_plus_plus.dylib
 
-    name: Build Rust ${{ matrix.platform.build_for }}
+    name: Build Rust ${{ matrix.platform.build_for }} ${{ matrix.build_type }}
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout
@@ -129,7 +129,7 @@ jobs:
     
     needs: [lint-rust, build-rust]
     runs-on: ubuntu-22.04
-    name: Build Godot ${{ matrix.platform.export }}
+    name: Build Godot ${{ matrix.platform.export }}  ${{ matrix.build_type }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-${{ matrix.platform.build_for }}-${{ matrix.build_type }}
-          path: rust/target/${{ matrix.platform.target }}/release/
+          path: rust/target/${{ matrix.platform.target }}/${{ matrix.build_type }}/
       - name: Download rust linux bin  # We always need the bin for the platform we're running on, in the debug dir
         uses: actions/download-artifact@v4
         with:
@@ -184,7 +184,7 @@ jobs:
     
     runs-on: ubuntu-22.04
     environment: main
-    name: Publish Web
+    name: Publish Web ${{ matrix.build_type }}
     needs: [build-godot]
     steps:
       - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,7 +180,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [release, debug]
+        build_type: [release]  # debug blocks_plus_plus.wasm is 62.4 MiB and I'm not uploading more stuff to R2
     
     runs-on: ubuntu-22.04
     environment: main
@@ -198,13 +198,12 @@ jobs:
         run: |
           cp deploy/cloudflare-pages/* wasm32/
           # exclude the engine file from cloudflare pages because it's too big
-          engine_hash=($(sha256sum wasm32/index.side.wasm))
+          export engine_hash=($(sha256sum wasm32/index.side.wasm))
           rm wasm32/index.side.wasm
           # ugly hack to force godot to pull the engine from another domain
-          build_type=${{ matrix.build_type }}
-          sed -i "s/{{{DIR}}}/${build_type}_${GODOT_VERSION}_${engine_hash[1]}/" deploy/templates/readAsyncNew
-          sed -e '/readAsync = (url, onload, onerror) => {/{r readAsyncNew' -e 'd;}' wasm32/index.js > _index.js
-          mv _index.js wasm32/index.js
+          export build_type=${{ matrix.build_type }}
+          sed -i -e "s|{{{DIR}}}|${build_type}_${GODOT_VERSION}_${engine_hash[0]}|g" deploy/templates/readAsyncNew
+          sed -i -e '/readAsync = (url, onload, onerror) => {/{r deploy/templates/readAsyncNew' -e 'd;}' wasm32/index.js
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform.build_for }}_${{ matrix.platform.bin }}
+          name: rust-${{ matrix.platform.build_for }}-${{ matrix.build_type }}
           path: rust/target/${{ matrix.platform.target }}/${{ matrix.build_type }}/${{ matrix.platform.bin }}
   
   build-godot:
@@ -100,29 +100,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_type: [release, debug]
         platform:
           - build_for: linux-x86_64
             export: linux_x11
             target: x86_64-unknown-linux-gnu
-            bin: libblocks_plus_plus.so
             export_name: blocks-plus-plus.x86_64
 
           - build_for: wasm32
             export: web
             target: wasm32-unknown-emscripten
-            bin: blocks_plus_plus.wasm
             export_name: index.html
 
           - build_for: windows-x86_64
             export: windows
             target: x86_64-pc-windows-msvc
-            bin: blocks_plus_plus.dll
             export_name: blocks-plus-plus.exe
 
           - build_for: macos-x86_64
             export: macos
             target: x86_64-apple-darwin
-            bin: libblocks_plus_plus.dylib
             export_name: blocks-plus-plus.zip
 
           # - build_for: macos-aarch64
@@ -149,12 +146,12 @@ jobs:
       - name: Download rust bin
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.platform.build_for }}_${{ matrix.platform.bin }}
+          name: rust-${{ matrix.platform.build_for }}-${{ matrix.build_type }}
           path: rust/target/${{ matrix.platform.target }}/release/
       - name: Download rust linux bin  # We always need the bin for the platform we're running on, in the debug dir
         uses: actions/download-artifact@v4
         with:
-          name: linux-x86_64_libblocks_plus_plus.so
+          name: rust-linux-x86_64-debug
           path: rust/target/x86_64-unknown-linux-gnu/debug/
       - name: Download custom templates
         uses: dawidd6/action-download-artifact@v6
@@ -170,16 +167,21 @@ jobs:
           tree /home/runner/.local/share/godot
           mkdir -v -p build/${{ matrix.platform.build_for }}
           cd $GODOT_PROJECT_PATH
-          godot --headless --verbose --export-release ${{ matrix.platform.export }} ../build/${{ matrix.platform.build_for }}/${{ matrix.platform.export_name }}
+          godot --headless --verbose ${{ matrix.build_type == 'release' && '--export-release' || '--export-debug'}} ${{ matrix.platform.export }} ../build/${{ matrix.platform.build_for }}/${{ matrix.platform.export_name }}
         env:
           GODOT_URL: https://godot-engine.static.ilus.pw/index.side.wasm
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform.build_for }}
+          name: ${{ matrix.platform.build_for }}-${{ matrix.build_type }}
           path: build/${{ matrix.platform.build_for }}
   
   publish-web:
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [release, debug]
+    
     runs-on: ubuntu-22.04
     environment: main
     name: Publish Web
@@ -190,7 +192,7 @@ jobs:
       - name: Download Web build
         uses: actions/download-artifact@v4
         with:
-          name: wasm32
+          name: wasm32-${{ matrix.build_type }}
           path: wasm32
       - name: Prepare cloudflare publish
         run: |
@@ -199,7 +201,8 @@ jobs:
           engine_hash=($(sha256sum wasm32/index.side.wasm))
           rm wasm32/index.side.wasm
           # ugly hack to force godot to pull the engine from another domain
-          sed -i "s/{{{DIR}}}/release_${GODOT_VERSION}_${engine_hash[1]}/" deploy/templates/readAsyncNew
+          build_type=${{ matrix.build_type }}
+          sed -i "s/{{{DIR}}}/${build_type}_${GODOT_VERSION}_${engine_hash[1]}/" deploy/templates/readAsyncNew
           sed -e '/readAsync = (url, onload, onerror) => {/{r readAsyncNew' -e 'd;}' wasm32/index.js > _index.js
           mv _index.js wasm32/index.js
       - name: Publish to Cloudflare Pages
@@ -210,4 +213,4 @@ jobs:
           projectName: blocks-plus-plus
           directory: wasm32
           wranglerVersion: '3'
-          branch: ${{ github.head_ref || github.ref_name }}
+          branch: ${{ matrix.build_type == 'release' && ' ' || 'debug_'}}${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/compile_godot.yaml
+++ b/.github/workflows/compile_godot.yaml
@@ -248,8 +248,14 @@ jobs:
           path: templates
   
   publish-web:
-    name: Publish web engine to cloudflare
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [release]  # debug build is big, maybe i'll do it later
+
+    name: Publish ${{ matrix.build_type }} web engine to cloudflare
     runs-on: ubuntu-22.04
+    environment: main
     needs: [compile-web]
     steps:
       - name: Download web templates
@@ -258,29 +264,21 @@ jobs:
           name: templates-web-${{ env.GODOT_VERSION }}
       - name: Prepare Upload
         run: |
-          unzip templates-web-${{ env.GODOT_VERSION }}
+          unzip web_dlink_${{ matrix.build_type }}.zip -d template_files
+          mkdir engine
+          mv template_files/godot.side.wasm engine/index.side.wasm
+          export engine_hash=($(sha256sum engine/index.side.wasm))
+          echo "RELEASE_HASH=${engine_hash[0]}" >> $GITHUB_ENV
 
-          unzip web_dlink_release.zip -d release_files
-          mkdir release_engine
-          mv release_files/godot.side.wasm release_engine/index.side.wasm
-          release_hash=($(sha256sum release_engine/index.side.wasm))
-          echo "RELEASE_HASH=${release_hash[1]}" >> $GITHUB_ENV
-
-          unzip web_dlink_debug.zip -d debug_files
-          mkdir debug_engine
-          mv debug_files/godot.side.wasm debug_engine/index.side.wasm
-          debug_hash=($(sha256sum debug_engine/index.side.wasm))
-          echo "DEBUG_HASH=${debug_hash[1]}" >> $GITHUB_ENV
-          
           # Only Upload the engine if it doesn't exist already
-          curl --head --fail https://godot-engine.static.ilus.pw/index.side.wasm
-          if [ $? -ne 0 ]; then
+          curl --head --fail https://godot-engine.static.ilus.pw/${{ matrix.build_type }}_${{ env.GODOT_VERSION }}_${engine_hash[0]}/index.side.wasm || EXIT_CODE=$?
+          if [ -n "$EXIT_CODE" ]; then
             echo "UPLOAD_ENGINE=true" >> $GITHUB_ENV
           else
             echo "UPLOAD_ENGINE=false" >> $GITHUB_ENV
           fi
           
-      - name: Upload release engine to R2
+      - name: Upload ${{ matrix.build_type }} engine to R2
         if: env.UPLOAD_ENGINE == 'true'
         uses: jakejarvis/s3-sync-action@master
         with:
@@ -291,19 +289,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_REGION: auto
-          SOURCE_DIR: release_engine
-          DEST_DIR: release_${{ env.GODOT_VERSION }}_${{ env.RELEASE_HASH }}
-          
-      - name: Upload debug engine to R2
-        if: env.UPLOAD_ENGINE == 'true'
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --delete
-        env:
-          AWS_S3_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          AWS_S3_BUCKET: ${{ secrets.R2_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_REGION: auto
-          SOURCE_DIR: debug_engine
-          DEST_DIR: debug_${{ env.GODOT_VERSION }}_${{ env.DEBUG_HASH }}
+          SOURCE_DIR: engine
+          DEST_DIR: ${{ matrix.build_type }}_${{ env.GODOT_VERSION }}_${{ env.RELEASE_HASH }}

--- a/.github/workflows/compile_godot.yaml
+++ b/.github/workflows/compile_godot.yaml
@@ -248,9 +248,9 @@ jobs:
           path: templates
   
   publish-web:
-    name: Build web engine to cloudflare
+    name: Publish web engine to cloudflare
     runs-on: ubuntu-22.04
-    needs: [compile-linux]
+    needs: [compile-web]
     steps:
       - name: Download web templates
         uses: actions/download-artifact@v4

--- a/.github/workflows/compile_godot.yaml
+++ b/.github/workflows/compile_godot.yaml
@@ -246,3 +246,64 @@ jobs:
         with:
           name: templates-${{env.GODOT_VERSION}}
           path: templates
+  
+  publish-web:
+    name: Build web engine to cloudflare
+    runs-on: ubuntu-22.04
+    needs: [compile-linux]
+    steps:
+      - name: Download web templates
+        uses: actions/download-artifact@v4
+        with:
+          name: templates-web-${{ env.GODOT_VERSION }}
+      - name: Prepare Upload
+        run: |
+          unzip templates-web-${{ env.GODOT_VERSION }}
+
+          unzip web_dlink_release.zip -d release_files
+          mkdir release_engine
+          mv release_files/godot.side.wasm release_engine/index.side.wasm
+          release_hash=($(sha256sum release_engine/index.side.wasm))
+          echo "RELEASE_HASH=${release_hash[1]}" >> $GITHUB_ENV
+
+          unzip web_dlink_debug.zip -d debug_files
+          mkdir debug_engine
+          mv debug_files/godot.side.wasm debug_engine/index.side.wasm
+          debug_hash=($(sha256sum debug_engine/index.side.wasm))
+          echo "DEBUG_HASH=${debug_hash[1]}" >> $GITHUB_ENV
+          
+          # Only Upload the engine if it doesn't exist already
+          curl --head --fail https://godot-engine.static.ilus.pw/index.side.wasm
+          if [ $? -ne 0 ]; then
+            echo "UPLOAD_ENGINE=true" >> $GITHUB_ENV
+          else
+            echo "UPLOAD_ENGINE=false" >> $GITHUB_ENV
+          fi
+          
+      - name: Upload release engine to R2
+        if: env.UPLOAD_ENGINE == 'true'
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --delete
+        env:
+          AWS_S3_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          AWS_S3_BUCKET: ${{ secrets.R2_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          SOURCE_DIR: release_engine
+          DEST_DIR: release_${{ env.GODOT_VERSION }}_${{ env.RELEASE_HASH }}
+          
+      - name: Upload debug engine to R2
+        if: env.UPLOAD_ENGINE == 'true'
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --delete
+        env:
+          AWS_S3_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          AWS_S3_BUCKET: ${{ secrets.R2_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          SOURCE_DIR: debug_engine
+          DEST_DIR: debug_${{ env.GODOT_VERSION }}_${{ env.DEBUG_HASH }}

--- a/deploy/templates/readAsyncNew
+++ b/deploy/templates/readAsyncNew
@@ -1,4 +1,4 @@
 readAsync = (url, onload, onerror) => {
    if (url.endsWith(".side.wasm")) {
-    url = "https://godot-engine.static.ilus.pw/index.side.wasm"
+    url = "https://godot-engine.static.ilus.pw/{{{DIR}}}/index.side.wasm"
    }


### PR DESCRIPTION
- Move engine R2 upload to godot compile workflow
- Make full debug builds (not deployed because the rust lib is too big for cf-pages)
- engine name will change when contents change, so we can start caching it safely